### PR TITLE
remove uv errors when creating a new project on windows.

### DIFF
--- a/agentstack/cli/init.py
+++ b/agentstack/cli/init.py
@@ -1,7 +1,7 @@
-import os, sys
+import os
+import sys
 from typing import Optional
-from pathlib import Path
-import inquirer
+import questionary
 from textwrap import shorten
 
 from agentstack import conf, log
@@ -38,12 +38,12 @@ def require_uv():
 
 def prompt_slug_name() -> str:
     """Prompt the user for a project name."""
-    
+
     def _validate(slug_name: Optional[str]) -> bool:
         if not slug_name:
             log.error("Project name cannot be empty")
             return False
-            
+
         if not is_snake_case(slug_name):
             log.error("Project name must be snake_case")
             return False
@@ -53,22 +53,12 @@ def prompt_slug_name() -> str:
             return False
 
         return True
-    
-    def _prompt() -> str:
-        return inquirer.text(
-            message="Project name (snake_case)",
-        )
-    
+
     log.info(
         "Provide a project name. This will be used to create a new directory in the "
         "current path and will be used as the project name. 🐍 Must be snake_case."
     )
-    slug_name = None
-    while not _validate(slug_name):
-        slug_name = _prompt()
-    
-    assert slug_name  # appease type checker
-    return slug_name
+    return questionary.text("Project name (snake_case)", validate=_validate).ask()
 
 
 def select_template(slug_name: str, framework: Optional[str] = None) -> TemplateConfig:
@@ -77,16 +67,23 @@ def select_template(slug_name: str, framework: Optional[str] = None) -> Template
 
     EMPTY = 'empty'
     choices = [
-        (EMPTY, "🆕 Empty Project"),
+        questionary.Choice('🆕 Empty Project', EMPTY),
     ]
     for template in templates:
-        choices.append((template.name, shorten(f"⚡️ {template.name} - {template.description}", 80)))
+        choices.append(
+            questionary.Choice(f"⚡️ {template.name} - {shorten(template.description, 80)}", template.name)
+        )
 
-    choice = inquirer.list_input(
-        message="Do you want to start with a template?",
-        choices=[c[1] for c in choices],
-    )
-    template_name = next(c[0] for c in choices if c[1] == choice)
+    template_name = questionary.select(
+        "Do you want to start with a template?",
+        choices=choices,
+        use_indicator=True,
+        use_shortcuts=False,
+        use_jk_keys=False,
+        use_emacs_keys=False,
+        use_arrow_keys=True,
+        use_search_filter=True,
+    ).ask()
 
     if template_name == EMPTY:
         return TemplateConfig(
@@ -148,11 +145,11 @@ def init_project(
 
     if framework is None:
         framework = template_data.framework
-    
+
     if framework in frameworks.ALIASED_FRAMEWORKS:
         framework = frameworks.ALIASED_FRAMEWORKS[framework]
-    
-    if not framework in frameworks.SUPPORTED_FRAMEWORKS:
+
+    if framework not in frameworks.SUPPORTED_FRAMEWORKS:
         raise Exception(f"Framework '{framework}' is not supported.")
     log.info(f"Using framework: {framework}")
 
@@ -163,7 +160,7 @@ def init_project(
     packaging.create_venv()
     log.info("Installing dependencies...")
     packaging.install_project()
-    
+
     if repo.find_parent_repo(conf.PATH):
         # if a repo already exists, we don't want to initialize a new one
         log.info("Found existing git repository; disabling tracking.")

--- a/agentstack/cli/init.py
+++ b/agentstack/cli/init.py
@@ -1,6 +1,6 @@
-import os
-import sys
+import os, sys
 from typing import Optional
+from pathlib import Path
 import inquirer
 from textwrap import shorten
 
@@ -38,12 +38,12 @@ def require_uv():
 
 def prompt_slug_name() -> str:
     """Prompt the user for a project name."""
-
+    
     def _validate(slug_name: Optional[str]) -> bool:
         if not slug_name:
             log.error("Project name cannot be empty")
             return False
-
+            
         if not is_snake_case(slug_name):
             log.error("Project name must be snake_case")
             return False
@@ -53,12 +53,12 @@ def prompt_slug_name() -> str:
             return False
 
         return True
-
+    
     def _prompt() -> str:
         return inquirer.text(
             message="Project name (snake_case)",
         )
-
+    
     log.info(
         "Provide a project name. This will be used to create a new directory in the "
         "current path and will be used as the project name. 🐍 Must be snake_case."
@@ -66,7 +66,7 @@ def prompt_slug_name() -> str:
     slug_name = None
     while not _validate(slug_name):
         slug_name = _prompt()
-
+    
     assert slug_name  # appease type checker
     return slug_name
 
@@ -148,11 +148,11 @@ def init_project(
 
     if framework is None:
         framework = template_data.framework
-
+    
     if framework in frameworks.ALIASED_FRAMEWORKS:
         framework = frameworks.ALIASED_FRAMEWORKS[framework]
-
-    if framework not in frameworks.SUPPORTED_FRAMEWORKS:
+    
+    if not framework in frameworks.SUPPORTED_FRAMEWORKS:
         raise Exception(f"Framework '{framework}' is not supported.")
     log.info(f"Using framework: {framework}")
 
@@ -163,7 +163,7 @@ def init_project(
     packaging.create_venv()
     log.info("Installing dependencies...")
     packaging.install_project()
-
+    
     if repo.find_parent_repo(conf.PATH):
         # if a repo already exists, we don't want to initialize a new one
         log.info("Found existing git repository; disabling tracking.")

--- a/agentstack/packaging.py
+++ b/agentstack/packaging.py
@@ -10,7 +10,6 @@ from agentstack import conf, log
 
 
 DEFAULT_PYTHON_VERSION = "3.12"
-VENV_DIR_NAME: Path = Path(".venv")
 
 # filter uv output by these words to only show useful progress messages
 RE_UV_PROGRESS = re.compile(r'^(Resolved|Prepared|Installed|Uninstalled|Audited)')
@@ -22,6 +21,8 @@ RE_UV_PROGRESS = re.compile(r'^(Resolved|Prepared|Installed|Uninstalled|Audited)
 # site-packages directory; it's possible an environment variable can control this.
 def _get_executeable_paths():
     """Get environment paths based on platform."""
+    VENV_DIR_NAME = Path(".venv")
+
     python_path = '.venv/Scripts/python.exe' if sys.platform == 'win32' else '.venv/bin/python'
     venv_path = conf.PATH / VENV_DIR_NAME.absolute()
     return venv_path, python_path

--- a/agentstack/packaging.py
+++ b/agentstack/packaging.py
@@ -10,6 +10,7 @@ from agentstack import conf, log
 
 
 DEFAULT_PYTHON_VERSION = "3.12"
+VENV_DIR_NAME = Path(".venv")
 
 # filter uv output by these words to only show useful progress messages
 RE_UV_PROGRESS = re.compile(r'^(Resolved|Prepared|Installed|Uninstalled|Audited)')
@@ -21,14 +22,12 @@ RE_UV_PROGRESS = re.compile(r'^(Resolved|Prepared|Installed|Uninstalled|Audited)
 # site-packages directory; it's possible an environment variable can control this.
 def _get_executeable_paths():
     """Get environment paths based on platform."""
-    VENV_DIR_NAME = Path(".venv")
-
     python_path = '.venv/Scripts/python.exe' if sys.platform == 'win32' else '.venv/bin/python'
     venv_path = conf.PATH / VENV_DIR_NAME.absolute()
     return venv_path, python_path
 
 
-_PYTHON_EXECUTABLE, _VENV_PATH = _get_executeable_paths()
+_VENV_PATH, _PYTHON_EXECUTABLE = _get_executeable_paths()
 
 
 def install(package: str):

--- a/agentstack/packaging.py
+++ b/agentstack/packaging.py
@@ -10,7 +10,7 @@ from agentstack import conf, log
 
 
 DEFAULT_PYTHON_VERSION = "3.12"
-VENV_DIR_NAME = Path(".venv")
+VENV_DIR_NAME: Path = Path(".venv")
 
 # filter uv output by these words to only show useful progress messages
 RE_UV_PROGRESS = re.compile(r'^(Resolved|Prepared|Installed|Uninstalled|Audited)')

--- a/tests/test_compile_llms.py
+++ b/tests/test_compile_llms.py
@@ -5,88 +5,90 @@ import unittest
 from pathlib import Path
 
 import sys
+
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from docs.compile_llms_txt import compile_llms_txt
+
 
 class TestCompileLLMsTxt(unittest.TestCase):
     def setUp(self):
         self.original_cwd = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        
+
         # Create a temporary directory for test files
         self.test_dir = tempfile.mkdtemp()
         self.docs_dir = Path(self.test_dir)
-        
+
         # Change to the temporary directory
         os.chdir(self.docs_dir)
-        
+
     def tearDown(self):
         os.chdir(self.original_cwd)
         shutil.rmtree(self.test_dir)
-        
+
     def create_test_mdx_file(self, path: str, content: str):
         """Helper to create test MDX files"""
         file_path = self.docs_dir / path
         file_path.parent.mkdir(parents=True, exist_ok=True)
         file_path.write_text(content)
-        
+
     def test_basic_compilation(self):
         """Test basic MDX file compilation"""
         # Create test MDX files
         self.create_test_mdx_file("test1.mdx", "Test content 1")
         self.create_test_mdx_file("test2.mdx", "Test content 2")
-        
+
         # Run compilation
         compile_llms_txt()
-        
+
         # Check output file exists and contains expected content
         output_path = self.docs_dir / "llms.txt"
         self.assertTrue(output_path.exists())
-        
+
         content = output_path.read_text()
         self.assertIn("## test1.mdx", content)
         self.assertIn("Test content 1", content)
         self.assertIn("## test2.mdx", content)
         self.assertIn("Test content 2", content)
-        
+
     def test_excluded_directories(self):
         """Test that files in excluded directories are skipped"""
         # Create files in both regular and excluded directories
         self.create_test_mdx_file("regular/file.mdx", "Regular content")
         self.create_test_mdx_file("tool/file.mdx", "Tool content")
-        
+
         compile_llms_txt()
-        
+
         content = (self.docs_dir / "llms.txt").read_text()
         self.assertIn("Regular content", content)
         self.assertNotIn("Tool content", content)
-        
+
     def test_excluded_files(self):
         """Test that excluded files are skipped"""
         self.create_test_mdx_file("regular.mdx", "Regular content")
         self.create_test_mdx_file("tool.mdx", "Tool content")
-        
+
         compile_llms_txt()
-        
+
         content = (self.docs_dir / "llms.txt").read_text()
         self.assertIn("Regular content", content)
         self.assertNotIn("Tool content", content)
-        
+
     def test_nested_directories(self):
         """Test compilation from nested directory structure"""
         self.create_test_mdx_file("dir1/test1.mdx", "Content 1")
         self.create_test_mdx_file("dir1/dir2/test2.mdx", "Content 2")
-        
+
         compile_llms_txt()
-        
+
         content = (self.docs_dir / "llms.txt").read_text()
-        self.assertIn("## dir1/test1.mdx", content)
-        self.assertIn("## dir1/dir2/test2.mdx", content)
+        self.assertIn(f"## dir1{os.path.sep}test1.mdx", content)
+        self.assertIn(f"## dir1{os.path.sep}dir2{os.path.sep}test2.mdx", content)
         self.assertIn("Content 1", content)
         self.assertIn("Content 2", content)
-        
+
     def test_empty_directory(self):
         """Test compilation with no MDX files"""
         compile_llms_txt()
-        
+
         content = (self.docs_dir / "llms.txt").read_text()
-        self.assertEqual(content, "") 
+        self.assertEqual(content, "")

--- a/tests/test_frameworks.py
+++ b/tests/test_frameworks.py
@@ -1,5 +1,4 @@
-from typing import Callable
-import os, sys
+import os
 from pathlib import Path
 import shutil
 import unittest
@@ -21,10 +20,11 @@ class TestFrameworks(unittest.TestCase):
         self.framework = os.getenv('TEST_FRAMEWORK')
         self.project_dir = BASE_PATH / 'tmp' / self.framework / 'test_frameworks'
 
-        os.makedirs(self.project_dir)
+        # Clean up and recreate test directory
+        os.makedirs(self.project_dir, exist_ok=True)
         os.chdir(self.project_dir)  # importing the crewai module requires us to be in a working directory
-        os.makedirs(self.project_dir / 'src')
-        os.makedirs(self.project_dir / 'src' / 'config')
+        os.makedirs(self.project_dir / 'src', exist_ok=True)
+        os.makedirs(self.project_dir / 'src' / 'config', exist_ok=True)
 
         (self.project_dir / 'src' / '__init__.py').touch()
 
@@ -34,7 +34,9 @@ class TestFrameworks(unittest.TestCase):
             config.framework = self.framework
 
     def tearDown(self):
-        shutil.rmtree(self.project_dir)
+        # Change directory before cleanup to avoid Windows file locks
+        os.chdir(str(BASE_PATH))
+        shutil.rmtree(self.project_dir, ignore_errors=True)
 
     def _populate_min_entrypoint(self):
         """This entrypoint does not have any tools or agents."""
@@ -80,7 +82,7 @@ class TestFrameworks(unittest.TestCase):
             assert hasattr(module, method_name), f"Method {method_name} not implemented in {self.framework}"
 
     def test_get_framework_module_invalid(self):
-        with self.assertRaises(Exception) as context:
+        with self.assertRaises(Exception):
             frameworks.get_framework_module('invalid')
 
     def test_validate_project(self):
@@ -89,21 +91,21 @@ class TestFrameworks(unittest.TestCase):
 
     def test_validate_project_invalid(self):
         self._populate_min_entrypoint()
-        with self.assertRaises(ValidationError) as context:
+        with self.assertRaises(ValidationError):
             frameworks.validate_project()
 
     def test_validate_project_has_agent_no_task_invalid(self):
         self._populate_min_entrypoint()
         shutil.copy(BASE_PATH / 'fixtures/agents_max.yaml', self.project_dir / AGENTS_FILENAME)
-        
+
         frameworks.add_agent(self._get_test_agent())
-        with self.assertRaises(ValidationError) as context:
+        with self.assertRaises(ValidationError):
             frameworks.validate_project()
 
     def test_validate_project_has_task_no_agent_invalid(self):
         self._populate_min_entrypoint()
         frameworks.add_task(self._get_test_task())
-        with self.assertRaises(ValidationError) as context:
+        with self.assertRaises(ValidationError):
             frameworks.validate_project()
 
     def test_validate_project_missing_agent_method_invalid(self):
@@ -119,7 +121,7 @@ class TestFrameworks(unittest.TestCase):
   backstory: >-
     this is a backstory
   llm: openai/gpt-4o""")
-        with self.assertRaises(ValidationError) as context:
+        with self.assertRaises(ValidationError):
             frameworks.validate_project()
 
     def test_validate_project_missing_task_method_invalid(self):
@@ -134,8 +136,8 @@ class TestFrameworks(unittest.TestCase):
     Add your expected output here
   agent: >-
     default_agent""")
-                    
-        with self.assertRaises(ValidationError) as context:
+
+        with self.assertRaises(ValidationError):
             frameworks.validate_project()
 
     def test_get_agent_tool_names(self):
@@ -161,7 +163,7 @@ class TestFrameworks(unittest.TestCase):
 
     def test_add_tool_invalid(self):
         self._populate_min_entrypoint()
-        with self.assertRaises(ValidationError) as context:
+        with self.assertRaises(ValidationError):
             frameworks.add_tool(self._get_test_tool(), 'agent_name')
 
     def test_remove_tool(self):

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -1,11 +1,10 @@
 import unittest
-import os, sys
+import os
 import io
 import logging
 import shutil
 from pathlib import Path
 from agentstack import log, conf
-from agentstack.log import SUCCESS, NOTIFY
 
 BASE_PATH = Path(__file__).parent
 
@@ -17,7 +16,7 @@ class TestLog(unittest.TestCase):
         self.test_dir.mkdir(parents=True, exist_ok=True)
 
         conf.set_path(self.test_dir)
-        self.test_log_file = (self.test_dir / log.LOG_FILENAME)
+        self.test_log_file = self.test_dir / log.LOG_FILENAME
         self.test_log_file.touch()
 
         # Create string IO objects to capture stdout/stderr
@@ -30,7 +29,17 @@ class TestLog(unittest.TestCase):
         log.set_stderr(self.stderr)
 
     def tearDown(self):
-        shutil.rmtree(self.test_dir)
+        # Close all handlers before cleanup
+        logger = logging.getLogger('agentstack')
+        for handler in logger.handlers[:]:  # [:] creates a copy of the list
+            handler.close()
+            logger.removeHandler(handler)
+
+        # reset log -> change dir -> remove dir
+        log.instance = None
+        os.chdir(str(BASE_PATH))
+        if self.test_dir.exists():
+            shutil.rmtree(self.test_dir)
 
     def test_debug_message(self):
         log.debug("Debug message")

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -1,4 +1,4 @@
-import os, sys
+import os
 import shutil
 from pathlib import Path
 import unittest
@@ -11,7 +11,6 @@ from agentstack.exceptions import EnvironmentError
 import git
 
 
-
 BASE_PATH = Path(__file__).parent
 
 
@@ -19,13 +18,26 @@ class TestRepo(unittest.TestCase):
     def setUp(self):
         self.framework = os.getenv('TEST_FRAMEWORK')
         self.test_dir = BASE_PATH / 'tmp' / self.framework / 'test_repo'
-        os.makedirs(self.test_dir)
+        os.chdir(str(BASE_PATH))  # Change directory before cleanup to avoid Windows file locks
+        os.makedirs(self.test_dir, exist_ok=True)
         os.chdir(self.test_dir)  # gitpython needs a cwd
-        
+
         conf.set_path(self.test_dir)
 
     def tearDown(self):
-        shutil.rmtree(self.test_dir)
+        # Close any open git repo before cleanup
+        try:
+            git_repo = git.Repo(self.test_dir)
+            git_repo.close()
+        except (git.exc.InvalidGitRepositoryError, git.exc.NoSuchPathError):
+            pass
+
+        # Change directory out before removing
+        os.chdir(str(BASE_PATH))
+
+        # Remove the test directory
+        if self.test_dir.exists():
+            shutil.rmtree(self.test_dir, ignore_errors=True)
 
     def test_init(self):
         repo.init(force_creation=True)
@@ -41,8 +53,8 @@ class TestRepo(unittest.TestCase):
         self.assertEqual(commits[0].message, f"{repo.INITIAL_COMMIT_MESSAGE}{repo.AUTOMATION_NOTE}")
 
     def test_init_parent_repo_exists(self):
-        os.makedirs(self.test_dir.parent / '.git')
-        
+        os.makedirs(self.test_dir.parent / '.git', exist_ok=True)
+
         repo.init(force_creation=False)
         self.assertFalse((self.test_dir / '.git').is_dir())
 
@@ -126,30 +138,34 @@ class TestRepo(unittest.TestCase):
     def test_require_git_when_disabled_manually(self):
         # Disable git tracking
         repo.dont_track_changes()
-        
+
         with self.assertRaises(repo.TrackingDisabledError):
             repo._require_git()
-        
+
         # Reset _USE_GIT for other tests
         repo._USE_GIT = None
 
-    @parameterized.expand([
-        ("apt", "/usr/bin/apt", "Hint: run `sudo apt install git`"),
-        ("brew", "/usr/local/bin/brew", "Hint: run `brew install git`"),
-        ("port", "/opt/local/bin/port", "Hint: run `sudo port install git`"),
-        ("none", None, ""),
-    ])
+    @parameterized.expand(
+        [
+            ("apt", "/usr/bin/apt", "Hint: run `sudo apt install git`"),
+            ("brew", "/usr/local/bin/brew", "Hint: run `brew install git`"),
+            ("port", "/opt/local/bin/port", "Hint: run `sudo port install git`"),
+            ("none", None, ""),
+        ]
+    )
     @patch('agentstack.repo.should_track_changes', return_value=True)
     @patch('agentstack.repo.shutil.which')
-    def test_require_git_not_installed(self, name, package_manager_path, expected_hint, mock_which, mock_should_track):
+    def test_require_git_not_installed(
+        self, name, package_manager_path, expected_hint, mock_which, mock_should_track
+    ):
         mock_which.side_effect = lambda x: None if x != name else package_manager_path
-        
+
         with self.assertRaises(EnvironmentError) as context:
             repo._require_git()
-        
+
         error_message = str(context.exception)
         self.assertIn("git is not installed.", error_message)
-        
+
         if expected_hint:
             self.assertIn(expected_hint, error_message)
 
@@ -168,7 +184,7 @@ class TestRepo(unittest.TestCase):
                 (self.test_dir / "test_file.txt").touch()
                 transaction.add_message("Test message")
 
-            mock_commit.assert_called_once_with(f"Test message", ["test_file.txt"], automated=True)
+            mock_commit.assert_called_once_with("Test message", ["test_file.txt"], automated=True)
 
     def test_transaction_multiple_messages(self):
         repo.init(force_creation=True)
@@ -182,7 +198,7 @@ class TestRepo(unittest.TestCase):
                 transaction.add_message("Second message")
 
             mock_commit.assert_called_once_with(
-                f"First message, Second message", ["test_file.txt", "test_file_2.txt"], automated=True
+                "First message, Second message", ["test_file.txt", "test_file_2.txt"], automated=True
             )
 
     def test_transaction_no_changes(self):
@@ -242,20 +258,20 @@ class TestRepo(unittest.TestCase):
 
     def test_commit_user_changes(self):
         repo.init(force_creation=True)
-        
+
         # Create a new file
         test_file = self.test_dir / "user_file.txt"
         test_file.write_text("User content")
-        
+
         # Commit user changes
         repo.commit_user_changes()
-        
+
         # Check if the file was committed
         git_repo = git.Repo(self.test_dir)
         commits = list(git_repo.iter_commits())
-        
+
         self.assertEqual(len(commits), 2)  # Initial commit + user changes commit
         self.assertEqual(commits[0].message, f"{repo.USER_CHANGES_COMMIT_MESSAGE}{repo.AUTOMATION_NOTE}")
-        
+
         # Check if the file is no longer in uncommitted files
         self.assertNotIn("user_file.txt", repo.get_uncommitted_files())


### PR DESCRIPTION
## 📥 Pull Request
Windows errors on cli completion :(

**📘 Description**
```
🦾 Creating a new AgentStack project...
Using framework: crewai
Creating virtual environment...
uv: [error]
[WinError 10038] An operation was attempted on something that is not a socket
Installing dependencies...
uv: [error]
[WinError 10038] An operation was attempted on something that is not a socket
Retrying uv installation with --no-cache flag...
uv: [error]
[WinError 10038] An operation was attempted on something that is not a socket
📃 Added task "fetch_todays_weather" to your AgentStack project successfully!
📃 Added task "fetch_historic_weather" to your AgentStack project successfully!
🤖 Added agent "weatherman" to your AgentStack project successfully!
🚀 AgentStack project generated successfully!

To get started, activate the virtual environment with:
💫 cd my_agent
🌟 source .venv/bin/activate
Run your new agent with:
✨ agentstack run
Or, run agentstack quickstart or agentstack docs for more next steps.
```

**🧪 Testing**
All the tests with changes here fail by default on windows when running whatever flavor of the `tox` command you feel like. While going thru each one, it seems largely to be how the filesystem deals with existing files. I'm still trying to sus out any bad ideas in the tests since my pytest game is mid and my Cypress game is strong.
